### PR TITLE
Don't pass the filename around

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,17 @@ and run `bundle install` from your shell.
 
 ```ruby
 # a new TransactionList object:
-CodaStandard::Parser.new.parse(filename)
+CodaStandard::Parser.new(filename).parse
 
 # or an array of transactions:
-CodaStandard::Parser.new.parse(filename).transactions
+CodaStandard::Parser.new(filename).parse.transactions
 
 # or maybe the BIC:
-CodaStandard::Parser.new.parse(filename).current_bic => "GEBABEBB"
+CodaStandard::Parser.new(filename).parse.current_bic => "GEBABEBB"
 # also available are: old_balance, current_account, current_account_type
 
 # or print a more readable represenation of the file
-CodaStandard::Parser.new.show(filename)
+CodaStandard::Parser.new(filename).show
 ```
 
 The available getters for each transaction are: `name`, `currency`, `bic`, `address`, `postcode`, `city`, `country`, `amount`, `account`, `entry_date`, `reference_number` and `transaction_number`.

--- a/lib/coda_standard/parser.rb
+++ b/lib/coda_standard/parser.rb
@@ -2,13 +2,14 @@ module CodaStandard
   class Parser
     attr_reader :transactions, :old_balance, :current_bic, :current_account, :current_transaction
 
-    def initialize
+    def initialize(filename)
+      @filename = filename
       @transactions = TransactionList.new
       @current_transaction = Transaction.new
     end
 
-    def parse(file_name)
-      File.open(file_name).each do |row|
+    def parse
+      File.open(@filename).each do |row|
         line = Line.new(row)
         case
           when line.line =~ /^0/
@@ -47,8 +48,8 @@ module CodaStandard
       @transactions.current_account_type = account[:account_type]
     end
 
-    def show(file_name)
-      parse(file_name)
+    def show
+      parse
       puts "**--Transactions--**\n\n"
       puts "Account: #{@transactions.current_account} Account type: #{@transactions.current_account_type} BIC: #{@transactions.current_bic}"
       puts "Old balance: #{@transactions.old_balance} \n\n"

--- a/lib/coda_standard/parser.rb
+++ b/lib/coda_standard/parser.rb
@@ -3,8 +3,8 @@ module CodaStandard
     attr_reader :transactions, :old_balance, :current_bic, :current_account, :current_transaction
 
     def initialize(filename)
-      @filename = filename
-      @transactions = TransactionList.new
+      @filename            = filename
+      @transactions        = TransactionList.new
       @current_transaction = Transaction.new
     end
 
@@ -19,16 +19,16 @@ module CodaStandard
             @transactions.old_balance = line.old_balance
           when line.line =~ /^21/
             @current_transaction = @transactions.create
-            @current_transaction.entry_date = line.entry_date
-            @current_transaction.reference_number = line.reference_number
-            @current_transaction.amount = line.amount
+            @current_transaction.entry_date         = line.entry_date
+            @current_transaction.reference_number   = line.reference_number
+            @current_transaction.amount             = line.amount
             @current_transaction.transaction_number = line.transaction_number
           when line.line =~ /^22/
             @current_transaction.bic = line.bic
           when line.line =~ /^23/
             @current_transaction.currency = line.currency
-            @current_transaction.name = line.name
-            @current_transaction.account = line.account
+            @current_transaction.name     = line.name
+            @current_transaction.account  = line.account
           when line.line =~ /^32/
             set_address(line.address)
         end
@@ -37,14 +37,14 @@ module CodaStandard
     end
 
     def set_address(address)
-      @current_transaction.address = address[:address]
+      @current_transaction.address  = address[:address]
       @current_transaction.postcode = address[:postcode]
-      @current_transaction.city = address[:city]
-      @current_transaction.country = address[:country]
+      @current_transaction.city     = address[:city]
+      @current_transaction.country  = address[:country]
     end
 
     def set_account(account)
-      @transactions.current_account = account[:account_number]
+      @transactions.current_account      = account[:account_number]
       @transactions.current_account_type = account[:account_type]
     end
 

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -3,9 +3,8 @@ require_relative 'spec_helper'
 describe CodaStandard::Parser do
 
   before :each do
-    @file_name = 'spec/coda.cod'
-    @file = File.open( @file_name )
-    @parser = CodaStandard::Parser.new
+    filename = 'spec/coda.cod'
+    @parser = CodaStandard::Parser.new(filename)
   end
 
   describe "initialize" do
@@ -16,10 +15,11 @@ describe CodaStandard::Parser do
 
   describe "parse" do
     before :each do
-      @parser.parse(@file_name)
+      @parser.parse
     end
+
     it "returns a Transactions object" do
-        expect(@parser.parse(@file_name)).to be_a(CodaStandard::TransactionList)
+        expect(@parser.parse).to be_a(CodaStandard::TransactionList)
     end
   end
 
@@ -63,7 +63,8 @@ describe CodaStandard::Parser do
 
   describe "show" do
     it "shows the info from the transactions" do
-      expect{@parser.show(@file_name)}.to output("**--Transactions--**\n\nAccount: 539007547034 Account type: bban_be_account BIC: GEBABEBB\nOld balance: 57900,000 \n\n-- Transaction n.1 - number 100000834941 - in date 310315-- \n\n   RN: 0001500000103 Account: BE53900754703405 BIC:GKCCBEBB\n   Amount: 500,000 EUR\n   Name: LASTNM PERSON\n   Address: CHAUSSEE DE BIERE 10 1978 SOMECITY  \n\n-- Transaction n.2 - number 100000835749 - in date 310315-- \n\n   RN: 0001500000104 Account: LU539007547034898400 BIC:BILLLULL\n   Amount: 200,000 EUR\n   Name: M.JOHN DOE\n   Address: 5 STREET 3654 CITY  BELGIQUE \n\n").to_stdout
+      expect{@parser.show}.to output("**--Transactions--**\n\nAccount: 539007547034 Account type: bban_be_account BIC: GEBABEBB\nOld balance: 57900,000 \n\n-- Transaction n.1 - number 100000834941 - in date 310315-- \n\n   RN: 0001500000103 Account: BE53900754703405 BIC:GKCCBEBB\n   Amount: 500,000 EUR\n   Name: LASTNM PERSON\n   Address: CHAUSSEE DE BIERE 10 1978 SOMECITY  \n\n-- Transaction n.2 - number 100000835749 - in date 310315-- \n\n   RN: 0001500000104 Account: LU539007547034898400 BIC:BILLLULL\n   Amount: 200,000 EUR\n   Name: M.JOHN DOE\n   Address: 5 STREET 3654 CITY  BELGIQUE \n\n").to_stdout
     end
   end
+
 end


### PR DESCRIPTION
Why not pass the filename in the constructor and store it as an instance variable? This way you don't need to pass the filename around as a parameter and you can simply call `@filename` within the `Parser` class.
