### PR TITLE
Extract record matchers to seperate methods

### DIFF
--- a/lib/coda_standard.rb
+++ b/lib/coda_standard.rb
@@ -2,7 +2,7 @@ require "coda_standard/version"
 require "coda_standard/parser"
 require "coda_standard/transaction"
 require "coda_standard/transaction_list"
-require "coda_standard/line"
+require "coda_standard/record"
 
 module CodaStandard
 end

--- a/lib/coda_standard/parser.rb
+++ b/lib/coda_standard/parser.rb
@@ -12,24 +12,24 @@ module CodaStandard
       File.open(@filename).each do |line|
         record = Record.new(line)
         case
-          when line =~ /^0/
+          when record.header?
             @transactions.current_bic = record.current_bic
-          when line =~ /^1/
+          when record.data_old_balance?
             set_account(record.current_account)
             @transactions.old_balance = record.old_balance
-          when line =~ /^21/
+          when record.data_movement1?
             @current_transaction = @transactions.create
             @current_transaction.entry_date         = record.entry_date
             @current_transaction.reference_number   = record.reference_number
             @current_transaction.amount             = record.amount
             @current_transaction.transaction_number = record.transaction_number
-          when line =~ /^22/
+          when record.data_movement2?
             @current_transaction.bic = record.bic
-          when line =~ /^23/
+          when record.data_movement3?
             @current_transaction.currency = record.currency
             @current_transaction.name     = record.name
             @current_transaction.account  = record.account
-          when line =~ /^32/
+          when record.data_information2?
             set_address(record.address)
         end
       end

--- a/lib/coda_standard/parser.rb
+++ b/lib/coda_standard/parser.rb
@@ -9,28 +9,28 @@ module CodaStandard
     end
 
     def parse
-      File.open(@filename).each do |row|
-        line = Line.new(row)
+      File.open(@filename).each do |line|
+        record = Record.new(line)
         case
-          when line.line =~ /^0/
-            @transactions.current_bic = line.current_bic
-          when line.line =~ /^1/
-            set_account(line.current_account)
-            @transactions.old_balance = line.old_balance
-          when line.line =~ /^21/
+          when line =~ /^0/
+            @transactions.current_bic = record.current_bic
+          when line =~ /^1/
+            set_account(record.current_account)
+            @transactions.old_balance = record.old_balance
+          when line =~ /^21/
             @current_transaction = @transactions.create
-            @current_transaction.entry_date         = line.entry_date
-            @current_transaction.reference_number   = line.reference_number
-            @current_transaction.amount             = line.amount
-            @current_transaction.transaction_number = line.transaction_number
-          when line.line =~ /^22/
-            @current_transaction.bic = line.bic
-          when line.line =~ /^23/
-            @current_transaction.currency = line.currency
-            @current_transaction.name     = line.name
-            @current_transaction.account  = line.account
-          when line.line =~ /^32/
-            set_address(line.address)
+            @current_transaction.entry_date         = record.entry_date
+            @current_transaction.reference_number   = record.reference_number
+            @current_transaction.amount             = record.amount
+            @current_transaction.transaction_number = record.transaction_number
+          when line =~ /^22/
+            @current_transaction.bic = record.bic
+          when line =~ /^23/
+            @current_transaction.currency = record.currency
+            @current_transaction.name     = record.name
+            @current_transaction.account  = record.account
+          when line =~ /^32/
+            set_address(record.address)
         end
       end
       @transactions

--- a/lib/coda_standard/record.rb
+++ b/lib/coda_standard/record.rb
@@ -29,6 +29,30 @@ module CodaStandard
       @line = line
     end
 
+    def header?
+      @line.start_with? "0"
+    end
+
+    def data_old_balance?
+      @line.start_with? "1"
+    end
+
+    def data_movement1?
+      @line.start_with? "21"
+    end
+
+    def data_movement2?
+      @line.start_with? "22"
+    end
+
+    def data_movement3?
+      @line.start_with? "23"
+    end
+
+    def data_information2?
+      @line.start_with? "32"
+    end
+
     def current_bic
       extract(:current_bic)
     end

--- a/lib/coda_standard/record.rb
+++ b/lib/coda_standard/record.rb
@@ -1,7 +1,5 @@
 module CodaStandard
-  class Line
-    attr_reader :line
-
+  class Record
     FIELDS = {
       current_bic: /^0.{59}(.{11})/,
       current_account: /^1(.{41})/,

--- a/spec/record_spec.rb
+++ b/spec/record_spec.rb
@@ -2,91 +2,151 @@ require_relative 'spec_helper'
 
 describe CodaStandard::Record do
   before :each do
-    @line0 = CodaStandard::Record.new("0000031031520005                  MMIF SA/BANK              GEBABEBB   00538839354 00000                                       2")
-    @line1 = CodaStandard::Record.new("10016539007547034 EUR0BE                  0000000057900000300315MMIF SA/EVOCURE                                              017")
-    @line21 = CodaStandard::Record.new("21000100000001500000103        0000000000500000010415001500001101100000834941                                      31031501601 0")
-    @line21b = CodaStandard::Record.new("21000100000001500000103        0000000000500000010415001500001001100000834941                                      31031501601 0")
-    @line22 = CodaStandard::Record.new("2200010000                                                                                        GKCCBEBB                   1 0")
-    @line23 = CodaStandard::Record.new("2300010000BE53900754703405                  EURLASTNM PERSON                                                                 0 1")
-    @line32 = CodaStandard::Record.new("32000200015 STREET                                     3654 CITY BELGIQUE                                                    0 0")
+    @header_record = CodaStandard::Record.new("0000031031520005                  MMIF SA/BANK              GEBABEBB   00538839354 00000                                       2")
+    @old_balance_data_record = CodaStandard::Record.new("10016539007547034 EUR0BE                  0000000057900000300315MMIF SA/EVOCURE                                              017")
+    @data_movement1_record = CodaStandard::Record.new("21000100000001500000103        0000000000500000010415001500001101100000834941                                      31031501601 0")
+    @data_movement1b_record = CodaStandard::Record.new("21000100000001500000103        0000000000500000010415001500001001100000834941                                      31031501601 0")
+    @data_movement2_record = CodaStandard::Record.new("2200010000                                                                                        GKCCBEBB                   1 0")
+    @data_movement3_record = CodaStandard::Record.new("2300010000BE53900754703405                  EURLASTNM PERSON                                                                 0 1")
+    @data_information2_record = CodaStandard::Record.new("32000200015 STREET                                     3654 CITY BELGIQUE                                                    0 0")
     end
+
+  describe "data_header" do
+    it "returns true if the line starts with a zero" do
+      expect(@header_record.header?).to be true
+    end
+
+    it "returns false if the line does not start with a zero" do
+      expect(@old_balance_data_record.header?).to be false
+    end
+  end
+
+  describe "data_old_balance" do
+    it "returns true if the line starts with a one" do
+      expect(@old_balance_data_record.data_old_balance?).to be true
+    end
+
+    it "returns false if the line does not start with a one" do
+      expect(@header_record.data_old_balance?).to be false
+    end
+  end
+
+  describe "data_movement1" do
+    it "returns true if the line starts with a 21" do
+      expect(@data_movement1_record.data_movement1?).to be true
+    end
+
+    it "returns false if the line does not start with 21" do
+      expect(@header_record.data_movement1?).to be false
+    end
+  end
+
+  describe "data_movement2" do
+    it "returns true if the line starts with a 22" do
+      expect(@data_movement2_record.data_movement2?).to be true
+    end
+
+    it "returns false if the line does not start with 22" do
+      expect(@header_record.data_movement2?).to be false
+    end
+  end
+
+  describe "data_movement3" do
+    it "returns true if the line starts with a 23" do
+      expect(@data_movement3_record.data_movement3?).to be true
+    end
+
+    it "returns false if the line does not start with 23" do
+      expect(@header_record.data_movement3?).to be false
+    end
+  end
+
+  describe "data_information2" do
+    it "returns true if the line starts with a 32" do
+      expect(@data_information2_record.data_information2?).to be true
+    end
+
+    it "returns false if the line does not start with 32" do
+      expect(@header_record.data_information2?).to be false
+    end
+  end
 
   describe "current_bic" do
     it "extracts the current_bic" do
-      expect(@line0.current_bic).to eq("GEBABEBB")
+      expect(@header_record.current_bic).to eq("GEBABEBB")
     end
   end
 
   describe "current_account" do
     it "extracts the current_account" do
-      expect(@line1.current_account).to eq({account_number:"539007547034", account_type:"bban_be_account"})
+      expect(@old_balance_data_record.current_account).to eq({account_number:"539007547034", account_type:"bban_be_account"})
     end
   end
 
   describe "old_balance" do
     it "extracts the old_balance" do
-      expect(@line1.old_balance).to eq("57900,000")
+      expect(@old_balance_data_record.old_balance).to eq("57900,000")
     end
   end
 
   describe "entry_date" do
     it "extracts the entry_date" do
-      expect(@line21.entry_date).to eq("310315")
+      expect(@data_movement1_record.entry_date).to eq("310315")
     end
   end
 
   describe "reference_number" do
     it "extracts the reference_number" do
-      expect(@line21.reference_number).to eq("0001500000103")
+      expect(@data_movement1_record.reference_number).to eq("0001500000103")
     end
   end
 
   describe "amount" do
     it "extracts the amount" do
-      expect(@line21.amount).to eq("500,000")
+      expect(@data_movement1_record.amount).to eq("500,000")
     end
   end
 
   describe "bic" do
     it "extracts the bic" do
-      expect(@line22.bic).to eq("GKCCBEBB")
+      expect(@data_movement2_record.bic).to eq("GKCCBEBB")
     end
   end
 
   describe "currency" do
     it "extracts the currency" do
-      expect(@line23.currency).to eq("EUR")
+      expect(@data_movement3_record.currency).to eq("EUR")
     end
   end
 
   describe "name" do
     it "extracts the name" do
-      expect(@line23.name).to eq("LASTNM PERSON")
+      expect(@data_movement3_record.name).to eq("LASTNM PERSON")
     end
   end
 
   describe "account" do
     it "extracts the account" do
-      expect(@line23.account).to eq("BE53900754703405")
+      expect(@data_movement3_record.account).to eq("BE53900754703405")
     end
   end
 
   describe "transaction_number" do
     context "structured_number" do
       it "extracts the number" do
-        expect(@line21.transaction_number).to eq("100000834941")
+        expect(@data_movement1_record.transaction_number).to eq("100000834941")
       end
     end
     context "non-structured_number" do
       it "returns not structured" do
-        expect(@line21b.transaction_number).to eq("not structured")
+        expect(@data_movement1b_record.transaction_number).to eq("not structured")
       end
     end
   end
 
   describe "address" do
     it "extracts the address" do
-      expect(@line32.address).to eq({:address=>"5 STREET", :postcode=>"3654", :city=>"CITY", :country=>" BELGIQUE"})
+      expect(@data_information2_record.address).to eq({:address=>"5 STREET", :postcode=>"3654", :city=>"CITY", :country=>" BELGIQUE"})
     end
   end
 

--- a/spec/record_spec.rb
+++ b/spec/record_spec.rb
@@ -1,14 +1,14 @@
 require_relative 'spec_helper'
 
-describe CodaStandard::Line do
+describe CodaStandard::Record do
   before :each do
-    @line0 = CodaStandard::Line.new("0000031031520005                  MMIF SA/BANK              GEBABEBB   00538839354 00000                                       2")
-    @line1 = CodaStandard::Line.new("10016539007547034 EUR0BE                  0000000057900000300315MMIF SA/EVOCURE                                              017")
-    @line21 = CodaStandard::Line.new("21000100000001500000103        0000000000500000010415001500001101100000834941                                      31031501601 0")
-    @line21b = CodaStandard::Line.new("21000100000001500000103        0000000000500000010415001500001001100000834941                                      31031501601 0")
-    @line22 = CodaStandard::Line.new("2200010000                                                                                        GKCCBEBB                   1 0")
-    @line23 = CodaStandard::Line.new("2300010000BE53900754703405                  EURLASTNM PERSON                                                                 0 1")
-    @line32 = CodaStandard::Line.new("32000200015 STREET                                     3654 CITY BELGIQUE                                                    0 0")
+    @line0 = CodaStandard::Record.new("0000031031520005                  MMIF SA/BANK              GEBABEBB   00538839354 00000                                       2")
+    @line1 = CodaStandard::Record.new("10016539007547034 EUR0BE                  0000000057900000300315MMIF SA/EVOCURE                                              017")
+    @line21 = CodaStandard::Record.new("21000100000001500000103        0000000000500000010415001500001101100000834941                                      31031501601 0")
+    @line21b = CodaStandard::Record.new("21000100000001500000103        0000000000500000010415001500001001100000834941                                      31031501601 0")
+    @line22 = CodaStandard::Record.new("2200010000                                                                                        GKCCBEBB                   1 0")
+    @line23 = CodaStandard::Record.new("2300010000BE53900754703405                  EURLASTNM PERSON                                                                 0 1")
+    @line32 = CodaStandard::Record.new("32000200015 STREET                                     3654 CITY BELGIQUE                                                    0 0")
     end
 
   describe "current_bic" do


### PR DESCRIPTION
Includes the pull request from #4.

This pull request extracts the regex matchers in the [`Parser`](https://github.com/Bluesmile82/coda_standard/blob/master/lib/coda_standard/parser.rb#L15) class to the recently renamed `Record` class. Think this more clearly indicates the intent of the code: extract the header record, or extract the data information record instead of a non descriptive regex.
