### PR TITLE
Convert entry date to a Date

### DIFF
--- a/lib/coda_standard/parser.rb
+++ b/lib/coda_standard/parser.rb
@@ -55,7 +55,7 @@ module CodaStandard
     end
 
     def extract_data_movement1(record)
-      @current_transaction.entry_date         = record.entry_date
+      @current_transaction.entry_date         = Date.strptime(record.entry_date, '%d%m%y')
       @current_transaction.reference_number   = record.reference_number
       @current_transaction.amount             = record.amount
       @current_transaction.structured_communication = record.structured_communication


### PR DESCRIPTION
The transaction `entry_date` was returned as a string which makes it harder to work with in the implementing application. This converts the string to a Ruby date so the implementing library doesn't have to worry about the underlying formats.

I can now do:

```
%td= transaction.entry_date
```

Instead of:

```
%td= transaction.entry_date.insert(2,'-').insert(5,'-')
```

In the implementing application.

The implementing application should not be aware of the CODA date structures, that's the whole idea of the gem.
